### PR TITLE
Make Full Random work for real world maps, fixes #3

### DIFF
--- a/aoc-builtin-rms.h
+++ b/aoc-builtin-rms.h
@@ -6,8 +6,9 @@ typedef struct terrain_overrides {
 } terrain_overrides_t;
 
 typedef enum custom_map_type {
-  Standard,
-  RealWorld
+  Standard = 0,
+  RealWorld = 1,
+  None = -1
 } custom_map_type_t;
 
 typedef struct custom_map {


### PR DESCRIPTION
Replace the map type with a randomly picked one before AoC does so.

this keeps crashing once the game loads still, but i'm not sure if that is related to this patch.